### PR TITLE
Adds support to rewrite the ckan URL for calls to download resources or webhooks to CKAN instance.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -260,6 +260,12 @@ Configuration:
     # not be loaded into the datastore.
     ckanext.xloader.max_excerpt_lines = 100
 
+    # If set, it will rewrite the site url for fetching resources that have
+    # been uploaded to CKAN.
+    # It will also rewrite the URL for the Xloader webhooks calls back to CKAN.
+    # By default this option is empty - meaning no URL rewriting.
+    ckanext.xloader.rewrite_site_url=
+
 ------------------------
 Developer installation
 ------------------------

--- a/ckanext/xloader/action.py
+++ b/ckanext/xloader/action.py
@@ -71,7 +71,7 @@ def xloader_submit(context, data_dict):
     except logic.NotFound:
         return False
 
-    site_url = os.environ.get("XLOADER_CKAN_URL")
+    site_url = config.get('ckanext.xloader.rewrite_site_url', config.get('ckan.site_url'))
     callback_url = site_url + '/api/3/action/xloader_hook'
 
     site_user = p.toolkit.get_action('get_site_user')({'ignore_auth': True}, {})

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -225,6 +225,16 @@ def xloader_data_into_datastore_(input, job_dict):
     logger.info('Express Load completed')
 
 
+def _rewrite_resource_download_url(resource_url):
+    xloader_ckan_site_url = config.get('ckanext.xloader.rewrite_site_url')
+    if not xloader_ckan_site_url:
+        return resource_url
+    site_url = config.get('ckan.site_url')
+    if resource_url.lower().startswith(site_url.lower()):
+        return xloader_ckan_site_url + resource_url[len(site_url):]
+    return resource_url
+
+
 def _download_resource_data(resource, data, api_key, logger):
     '''Downloads the resource['url'] as a tempfile.
 
@@ -240,6 +250,8 @@ def _download_resource_data(resource, data, api_key, logger):
     '''
     # check scheme
     url = resource.get('url')
+    # Rewrite the URL if configured
+    url = _rewrite_resource_download_url(url)
     scheme = urlparse.urlsplit(url).scheme
     if scheme not in ('http', 'https', 'ftp'):
         raise JobError(


### PR DESCRIPTION
Adds support to rewrite the ckan URL for calls to download resources or webhooks to CKAN instance.
Useful if the configured `ckan.site_url` is not easily accessible from the xloader worker.